### PR TITLE
fixed: forgot to close open files.

### DIFF
--- a/phylo_cnv/genes.py
+++ b/phylo_cnv/genes.py
@@ -189,6 +189,8 @@ def build_pangenome_db(args, genome_clusters):
 				pangenome_map.write('%s\t%s\n' % (r.id, cluster_id))
 				db_stats['total_length'] += len(r.seq)
 				db_stats['total_seqs'] += 1
+	pangenome_fasta.close()
+	pangenome_map.close()
 	# print out database stats
 	print("  total genome-clusters: %s" % db_stats['genome_clusters'])
 	print("  total genes: %s" % db_stats['total_seqs'])


### PR DESCRIPTION
pangenome_fasta should be closed before running bowtie2-build. Otherwise, in some cases, bowtie2-build will be invoked before the buffer is written into the file. In this case, bowtie2-build will complain that all fasta files are empty, even though after python script exists, files are written and closed.